### PR TITLE
Garden Pool Dashboard fix to show pool water consumption 

### DIFF
--- a/configs/envbase/home_assistant_files/ha_dashboards/lovelace.garden_and_pool.json
+++ b/configs/envbase/home_assistant_files/ha_dashboards/lovelace.garden_and_pool.json
@@ -181,8 +181,7 @@
                       "type": "column",
                       "group_by": {
                         "duration": "1month",
-                        "func": "last",
-                        "fill": "last"
+                        "func": "max"
                       },
                       "unit": "L",
                       "color": "blue"


### PR DESCRIPTION
by month even after month passed