### PR TITLE
EVCC Wallbox and Vehicle Integration

### DIFF
--- a/configs/envbase/group_vars/home_assistant/apps-homeassistant-configuration.yaml
+++ b/configs/envbase/group_vars/home_assistant/apps-homeassistant-configuration.yaml
@@ -247,6 +247,7 @@ ha_hacs_components:
       - "Settings > Devices & Services > Add Integration > evcc."
       - "Enter EVCC configuration details."
       - "IMPORTANT: Huawei Solar and EVCC cannot be used at the same time!"
+      - "IMPORTANT: Call the integration evccDirect to avoid naming conflicts with MQTT EVCC sensors!"
 
   - full_name: "RomRider/apexcharts-card"
     repo_id: "331701152"
@@ -297,6 +298,8 @@ ha_hacs_components:
       - "manual entity mapping required."
       - "Lovelace YAML mode users only: register the resource manually at"
       - "/hacsfiles/hass-evcc-card/evcc-card.js (type: module)."
+      - "IMPORTANT: The EVCC HACS integration must be enabled first!"
+      - "IMPORTANT: Call the integration evccDirect to avoid naming conflicts with MQTT EVCC sensors!"
 
 # ---------- MQTT broker defaults ----------
 ha_mqtt_broker: mosquitto-broker
@@ -444,3 +447,4 @@ ha_integrations:
       - "Settings > Devices & Services > Add Integration > Ondilo ICO."
       - "When prompted, add Application Credentials (client_id / client_secret)"
       - "and complete the OAuth login in the browser. OAuth cannot be automated."
+      - "IMPORTANT: Use 'Pool Water Manager' as device name to ensure all code dashboards work properly!"

--- a/configs/envbase/group_vars/home_assistant/apps-homeassistant-configuration.yaml
+++ b/configs/envbase/group_vars/home_assistant/apps-homeassistant-configuration.yaml
@@ -425,6 +425,7 @@ ha_dashboard_files:
   - lovelace.energy_custom.json
   - lovelace.garden_and_pool.json
   - lovelace.pool_status_and_tech.json
+  - lovelace.vehicle_charging_control.json
 
 # ---------- Built-in HA integrations requiring manual configuration ----------
 # Use this list for integrations that ship inside HA Core (no install step

--- a/configs/envbase/group_vars/incus_scope/apps-evcc-configuration.yaml
+++ b/configs/envbase/group_vars/incus_scope/apps-evcc-configuration.yaml
@@ -34,6 +34,16 @@
 #   evcc_inverter1_battery_maxchargepower: Max battery charge power in W
 #                          (required by huawei-sun2000-hybrid for usage=battery)
 #
+# Optional variables (environment layer, rendered only when defined):
+#   evcc_sponsortoken:  Sponsor token for sponsor-only device templates
+#                       (e.g. the Huawei ocpp-huawei charger).
+#   evcc_vehicles:      List of vehicle dicts (name/type/template plus optional
+#                       title/user/password/vin/capacity/phases/mode).
+#   evcc_chargers:      List of charger dicts (name/type/template plus optional
+#                       stationid/connector/status/power/enabled/maxcurrent).
+#   evcc_loadpoints:    List of loadpoint dicts (title/charger plus optional
+#                       vehicle/meter/mode/phases/priority).
+#
 # References:
 #   - https://docs.evcc.io/en/docs/installation/configuration
 #   - https://docs.evcc.io/en/docs/devices/meters#sun2000-hybrid-inverter

--- a/configs/envbase/group_vars/incus_scope/apps-evcc-configuration.yaml
+++ b/configs/envbase/group_vars/incus_scope/apps-evcc-configuration.yaml
@@ -33,6 +33,8 @@
 #   evcc_inverter2_id:      Modbus unit id (typically 1)
 #   evcc_inverter1_battery_maxchargepower: Max battery charge power in W
 #                          (required by huawei-sun2000-hybrid for usage=battery)
+#   evcc_inverter1_battery_maxdischargepower: Max battery discharge power in W
+#                          (required by huawei-sun2000-hybrid for usage=battery)
 #
 # Optional variables (environment layer, rendered only when defined):
 #   evcc_sponsortoken:  Sponsor token for sponsor-only device templates
@@ -147,6 +149,7 @@ evcc_meters:
     id: "{{ evcc_inverter1_id }}"
     timeout: "{{ evcc_meter_timeout }}"
     maxchargepower: "{{ evcc_inverter1_battery_maxchargepower }}"
+    maxdischargepower: "{{ evcc_inverter1_battery_maxdischargepower }}"
   - name: huawei_inv2_pv
     type: template
     template: huawei-sun2000-inverter

--- a/configs/envbase/group_vars/incus_scope/apps-evcc-configuration.yaml
+++ b/configs/envbase/group_vars/incus_scope/apps-evcc-configuration.yaml
@@ -13,14 +13,13 @@
 # as the inverter DNS names / IPs / Modbus unit ids are intentionally NOT
 # set here — they must be provided by the environment layer.
 #
-# DESIGN NOTE — no Modbus proxy:
-# The Huawei SUN2000 SDongleA does not respond to Modbus/TCP requests when
-# they are relayed by an intermediate proxy (verified empirically with both
-# EVCC's built-in modbusproxy and tiagocoutinho/modbus-proxy). EVCC's
-# meters therefore connect to the dongles directly using the connect-read-
-# close pattern of the huawei-sun2000-hybrid template. Each dongle's
-# single Modbus/TCP slot is owned by EVCC; data sharing with other systems
-# (Home Assistant, …) must go through MQTT.
+# DESIGN NOTE — Modbus proxy:
+# EVCC's meters connect to the dongles directly using the connect-read-close
+# pattern of the huawei-sun2000-hybrid template. Environments may additionally
+# expose those shared connections through EVCC's built-in modbusproxy. Earlier
+# EVCC releases could not proxy the Huawei SUN2000 SDongleA at all; this started
+# working with EVCC 0.313.2. Enable it per environment and keep external polling
+# conservative, since the SDongleA still has a very small Modbus budget.
 #
 # Required seed variables from the environment layer:
 #   evcc_incus_remote:      Incus remote name (e.g., "incus.peladin.mszlocal")
@@ -38,7 +37,8 @@
 #
 # Optional variables (environment layer, rendered only when defined):
 #   evcc_sponsortoken:  Sponsor token for sponsor-only device templates
-#                       (e.g. the Huawei ocpp-huawei charger).
+#                       and the Modbus proxy.
+#   evcc_modbusproxy:   List of proxy listeners (port, uri, readonly).
 #   evcc_vehicles:      List of vehicle dicts (name/type/template plus optional
 #                       title/user/password/vin/capacity/phases/mode).
 #   evcc_chargers:      List of charger dicts (name/type/template plus optional

--- a/configs/envbase/group_vars/incus_scope/apps-evcc-configuration.yaml
+++ b/configs/envbase/group_vars/incus_scope/apps-evcc-configuration.yaml
@@ -39,6 +39,8 @@
 #   evcc_sponsortoken:  Sponsor token for sponsor-only device templates
 #                       and the Modbus proxy.
 #   evcc_modbusproxy:   List of proxy listeners (port, uri, readonly).
+#   evcc_inverter1_proxy_port / evcc_inverter2_proxy_port:
+#                       Listener ports for the proxy (default 1502 / 1503).
 #   evcc_vehicles:      List of vehicle dicts (name/type/template plus optional
 #                       title/user/password/vin/capacity/phases/mode).
 #   evcc_chargers:      List of charger dicts (name/type/template plus optional
@@ -75,6 +77,12 @@ evcc_interval: 60s
 # Per-meter Modbus timeout. The default in the SUN2000 templates is 15s;
 # we bump it so a momentarily busy dongle does not surface an error.
 evcc_meter_timeout: 30s
+
+# Default listener ports for the optional Modbus proxy (evcc_modbusproxy in the
+# environment layer re-exposes EVCC's shared inverter connections). Override per
+# environment if these clash with other services on the EVCC container's LAN IP.
+evcc_inverter1_proxy_port: 502
+evcc_inverter2_proxy_port: 503
 
 # ---------- MQTT integration ----------
 # When evcc_mqtt is defined the template renders an `mqtt:` block so EVCC

--- a/configs/envbase/home_assistant_files/ha_dashboards/lovelace.vehicle_charging_control.json
+++ b/configs/envbase/home_assistant_files/ha_dashboards/lovelace.vehicle_charging_control.json
@@ -1,0 +1,73 @@
+{
+  "version": 1,
+  "minor_version": 1,
+  "key": "lovelace.vehicle_charging_control",
+  "data": {
+    "config": {
+      "views": [
+        {
+          "type": "sections",
+          "sections": [
+            {
+              "type": "grid",
+              "cards": [
+                {
+                  "type": "heading",
+                  "heading": "Charge Control",
+                  "heading_style": "title"
+                },
+                {
+                  "type": "custom:evcc-card",
+                  "mode": "compact",
+                  "size": "large"
+                }
+              ]
+            },
+            {
+              "type": "grid",
+              "cards": [
+                {
+                  "type": "heading",
+                  "heading_style": "title",
+                  "heading": "House Battery Lock"
+                },
+                {
+                  "type": "custom:evcc-card",
+                  "mode": "flow",
+                  "stats_period": "month",
+                  "size": "large"
+                }
+              ]
+            },
+            {
+              "type": "grid",
+              "cards": [
+                {
+                  "type": "heading",
+                  "heading": "Energy Flow (takes a few seconds to update)",
+                  "heading_style": "title"
+                },
+                {
+                  "type": "custom:evcc-card",
+                  "mode": "battery",
+                  "charge_current_settings": "collapsed",
+                  "size": "large"
+                }
+              ]
+            }
+          ],
+          "max_columns": 4,
+          "title": "Car Charging",
+          "cards": [],
+          "header": {
+            "card": {
+              "type": "markdown",
+              "text_only": true,
+              "content": "# Vehicle / Car Charging "
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/configs/envbase/home_assistant_files/ha_dashboards/lovelace_dashboards.json
+++ b/configs/envbase/home_assistant_files/ha_dashboards/lovelace_dashboards.json
@@ -30,6 +30,15 @@
         "require_admin": false,
         "mode": "storage",
         "url_path": "pool-status-and-tech"
+      },
+      {
+        "id": "vehicle_charging_control",
+        "show_in_sidebar": true,
+        "title": "Vehicle Charging Control",
+        "require_admin": false,
+        "mode": "storage",
+        "url_path": "vehicle-charging-control",
+        "icon": "mdi:car-electric"
       }
     ]
   }

--- a/playbooks/ring1/apps-evcc-configure.yaml
+++ b/playbooks/ring1/apps-evcc-configure.yaml
@@ -47,9 +47,6 @@
           - evcc_interval is defined
           - evcc_meters is defined
           - evcc_meters | length > 0
-          - evcc_inverter1_host is defined
-          - evcc_inverter2_host is defined
-          - evcc_inverter1_battery_maxchargepower is defined
           # When evcc_mqtt is provided it must include host + topic.
           - (evcc_mqtt is not defined) or
             (evcc_mqtt.host is defined and evcc_mqtt.host | length > 0
@@ -57,9 +54,24 @@
         fail_msg: >
           Missing EVCC configuration variables. Ensure
           group_vars/incus_scope/apps-evcc-configuration.yaml is present in
-          both envbase and your environment inventory (the environment
-          layer must provide evcc_inverter1_host / _inverter2_host and
-          friends).
+          both envbase and your environment inventory.
+
+    # Real Huawei meters connect over Modbus/TCP and therefore need the
+    # inverter endpoints from the environment layer. Demo setups (e.g.
+    # envlocaldev overriding evcc_meters with demo-meter / demo-battery)
+    # carry no Modbus fields, so these variables are not required there.
+    - name: Validate Modbus inverter endpoints when real meters are used
+      ansible.builtin.assert:
+        that:
+          - evcc_inverter1_host is defined
+          - evcc_inverter2_host is defined
+          - evcc_inverter1_battery_maxchargepower is defined
+        fail_msg: >
+          Missing EVCC Modbus configuration variables. At least one meter in
+          evcc_meters uses Modbus, so the environment layer must provide
+          evcc_inverter1_host / _inverter2_host and
+          evcc_inverter1_battery_maxchargepower.
+      when: evcc_meters | selectattr('modbus', 'defined') | list | length > 0
 
     - name: Set Incus remote prefix for instance addressing
       ansible.builtin.set_fact:

--- a/playbooks/ring1/apps-evcc-configure.yaml
+++ b/playbooks/ring1/apps-evcc-configure.yaml
@@ -103,6 +103,32 @@
         (evcc_chargers | default([]) | selectattr('template', 'defined')
          | selectattr('template', 'match', '^ocpp-') | list | length) > 0
 
+    - name: Validate Modbus proxy configuration
+      ansible.builtin.assert:
+        that:
+          - item.port is defined
+          - item.uri is defined
+          - item.uri | length > 0
+          - item.readonly | default('deny') in ['false', 'true', 'deny']
+        fail_msg: >
+          Each evcc_modbusproxy entry must define a listener port, an upstream
+          uri, and optionally readonly as false, true, or deny.
+      loop: "{{ evcc_modbusproxy | default([]) }}"
+      loop_control:
+        label: "{{ item.port | default('missing port') }}"
+
+    - name: Validate Modbus proxy prerequisites
+      ansible.builtin.assert:
+        that:
+          - evcc_sponsortoken is defined
+          - evcc_sponsortoken | length > 0
+          - (evcc_modbusproxy | map(attribute='port') | list | unique | length) ==
+            (evcc_modbusproxy | length)
+        fail_msg: >
+          EVCC's Modbus proxy requires a sponsor token and a unique listener
+          port for each upstream connection.
+      when: evcc_modbusproxy is defined and evcc_modbusproxy | length > 0
+
     - name: Set Incus remote prefix for instance addressing
       ansible.builtin.set_fact:
         _incus_remote_prefix: "{{ (evcc_incus_remote + ':') if evcc_incus_remote != 'local' else '' }}"

--- a/playbooks/ring1/apps-evcc-configure.yaml
+++ b/playbooks/ring1/apps-evcc-configure.yaml
@@ -73,6 +73,35 @@
           evcc_inverter1_battery_maxchargepower.
       when: evcc_meters | selectattr('modbus', 'defined') | list | length > 0
 
+    - name: Validate loadpoints reference defined chargers (and vehicles)
+      ansible.builtin.assert:
+        that:
+          - item.charger is defined
+          - (evcc_chargers | default([]) | map(attribute='name') | list) is contains(item.charger)
+          - (item.vehicle is not defined) or
+            ((evcc_vehicles | default([]) | map(attribute='name') | list) is contains(item.vehicle))
+        fail_msg: >
+          Loadpoint '{{ item.title | default(item.charger | default('?')) }}'
+          references a charger/vehicle that is not declared in evcc_chargers /
+          evcc_vehicles.
+      loop: "{{ evcc_loadpoints | default([]) }}"
+      loop_control:
+        label: "{{ item.title | default(item.charger | default('loadpoint')) }}"
+      when: evcc_loadpoints is defined
+
+    - name: Validate sponsor token is present when a sponsor-only charger is used
+      ansible.builtin.assert:
+        that:
+          - evcc_sponsortoken is defined
+          - evcc_sponsortoken | length > 0
+        fail_msg: >
+          At least one charger uses a sponsor-only template (ocpp-*), so
+          evcc_sponsortoken must be provided by the environment layer. See
+          https://docs.evcc.io/en/sponsorship
+      when: >
+        (evcc_chargers | default([]) | selectattr('template', 'defined')
+         | selectattr('template', 'match', '^ocpp-') | list | length) > 0
+
     - name: Set Incus remote prefix for instance addressing
       ansible.builtin.set_fact:
         _incus_remote_prefix: "{{ (evcc_incus_remote + ':') if evcc_incus_remote != 'local' else '' }}"

--- a/playbooks/ring1/apps-evcc-configure.yaml
+++ b/playbooks/ring1/apps-evcc-configure.yaml
@@ -66,11 +66,12 @@
           - evcc_inverter1_host is defined
           - evcc_inverter2_host is defined
           - evcc_inverter1_battery_maxchargepower is defined
+          - evcc_inverter1_battery_maxdischargepower is defined
         fail_msg: >
           Missing EVCC Modbus configuration variables. At least one meter in
           evcc_meters uses Modbus, so the environment layer must provide
           evcc_inverter1_host / _inverter2_host and
-          evcc_inverter1_battery_maxchargepower.
+          evcc_inverter1_battery_maxchargepower / _maxdischargepower.
       when: evcc_meters | selectattr('modbus', 'defined') | list | length > 0
 
     - name: Validate loadpoints reference defined chargers (and vehicles)

--- a/playbooks/ring1/templates/evcc.yaml.j2
+++ b/playbooks/ring1/templates/evcc.yaml.j2
@@ -66,6 +66,18 @@ meters:
 {%   if meter.power is defined %}
     power: {{ meter.power }}
 {%   endif %}
+{%   if meter.energy is defined %}
+    energy: {{ meter.energy }}
+{%   endif %}
+{%   if meter.currentL1 is defined %}
+    currentL1: {{ meter.currentL1 }}
+{%   endif %}
+{%   if meter.currentL2 is defined %}
+    currentL2: {{ meter.currentL2 }}
+{%   endif %}
+{%   if meter.currentL3 is defined %}
+    currentL3: {{ meter.currentL3 }}
+{%   endif %}
 {%   if meter.soc is defined %}
     soc: {{ meter.soc }}
 {%   endif %}
@@ -127,10 +139,131 @@ mqtt:
 {%   endif %}
 {% endif %}
 
+# ---------------------------------------------------------------------------
+# Sponsor token
+# Required by sponsor-only device templates (e.g. the Huawei ocpp-huawei
+# charger). See https://docs.evcc.io/en/sponsorship
+# ---------------------------------------------------------------------------
+{% if evcc_sponsortoken is defined and evcc_sponsortoken | length > 0 %}
+sponsortoken: {{ evcc_sponsortoken }}
+{% endif %}
+
+# ---------------------------------------------------------------------------
+# Vehicles
 #
-# loadpoints: []
-# chargers: []
-# vehicles: []
+# Production (envprod): real vehicle bound to its manufacturer cloud API
+# (e.g. Polestar) for live SoC. Demo (envlocaldev): the `offline` template
+# with no API, only title / capacity.
+#
+# Rendered generically like the meters above: connection / credential fields
+# are only emitted when present, so a single template serves both setups.
+# See https://docs.evcc.io/en/reference/configuration/vehicles
+# ---------------------------------------------------------------------------
+{% if evcc_vehicles is defined and evcc_vehicles | length > 0 %}
+vehicles:
+{% for vehicle in evcc_vehicles %}
+  - name: {{ vehicle.name }}
+    type: {{ vehicle.type }}
+    template: {{ vehicle.template }}
+{%   if vehicle.title is defined %}
+    title: {{ vehicle.title }}
+{%   endif %}
+{%   if vehicle.user is defined %}
+    user: {{ vehicle.user }}
+{%   endif %}
+{%   if vehicle.password is defined %}
+    password: {{ vehicle.password }}
+{%   endif %}
+{%   if vehicle.vin is defined %}
+    vin: {{ vehicle.vin }}
+{%   endif %}
+{%   if vehicle.capacity is defined %}
+    capacity: {{ vehicle.capacity }}
+{%   endif %}
+{%   if vehicle.phases is defined %}
+    phases: {{ vehicle.phases }}
+{%   endif %}
+{%   if vehicle.mode is defined %}
+    mode: {{ vehicle.mode }}
+{%   endif %}
+{% endfor %}
+{% endif %}
+
+# ---------------------------------------------------------------------------
+# Chargers
+#
+# Production (envprod): Huawei SCharger-22KT-S0 via the sponsor-only
+# `ocpp-huawei` template. The charger dials into evcc's built-in OCPP server
+# (default port 8887) over the LAN — the evcc container is bridged with its
+# own IP, so no port mapping is required.
+#
+# Demo (envlocaldev): the `demo-charger` template with fixed status / power.
+#
+# Rendered generically: fields are only emitted when present.
+# See https://docs.evcc.io/en/reference/configuration/chargers
+# ---------------------------------------------------------------------------
+{% if evcc_chargers is defined and evcc_chargers | length > 0 %}
+chargers:
+{% for charger in evcc_chargers %}
+  - name: {{ charger.name }}
+    type: {{ charger.type }}
+    template: {{ charger.template }}
+{%   if charger.stationid is defined %}
+    stationid: {{ charger.stationid }}
+{%   endif %}
+{%   if charger.connector is defined %}
+    connector: {{ charger.connector }}
+{%   endif %}
+{%   if charger.status is defined %}
+    status: {{ charger.status }}
+{%   endif %}
+{%   if charger.power is defined %}
+    power: {{ charger.power }}
+{%   endif %}
+{%   if charger.enabled is defined %}
+    enabled: {{ charger.enabled | string | lower }}
+{%   endif %}
+{%   if charger.maxcurrent is defined %}
+    maxcurrent: {{ charger.maxcurrent }}
+{%   endif %}
+{% endfor %}
+{% endif %}
+
+# ---------------------------------------------------------------------------
+# Loadpoints (bind a charger — and optionally a vehicle — into a charging
+# point that appears in the evcc dashboard)
+# See https://docs.evcc.io/en/reference/configuration/loadpoints
+# ---------------------------------------------------------------------------
+{% if evcc_loadpoints is defined and evcc_loadpoints | length > 0 %}
+loadpoints:
+{% for lp in evcc_loadpoints %}
+  - title: {{ lp.title }}
+    charger: {{ lp.charger }}
+{%   if lp.vehicle is defined %}
+    vehicle: {{ lp.vehicle }}
+{%   endif %}
+{%   if lp.meter is defined %}
+    meter: {{ lp.meter }}
+{%   endif %}
+{%   if lp.mode is defined %}
+    mode: {{ lp.mode }}
+{%   endif %}
+{%   if lp.phases is defined %}
+    phases: {{ lp.phases }}
+{%   endif %}
+{%   if lp.minCurrent is defined %}
+    minCurrent: {{ lp.minCurrent }}
+{%   endif %}
+{%   if lp.maxCurrent is defined %}
+    maxCurrent: {{ lp.maxCurrent }}
+{%   endif %}
+{%   if lp.priority is defined %}
+    priority: {{ lp.priority }}
+{%   endif %}
+{% endfor %}
+{% endif %}
+
+#
 # tariffs: {}
 # influx: {}
 # hems: {}

--- a/playbooks/ring1/templates/evcc.yaml.j2
+++ b/playbooks/ring1/templates/evcc.yaml.j2
@@ -29,11 +29,24 @@ interval: {{ evcc_interval }}
 #   modbus: trace
 
 # ---------------------------------------------------------------------------
+# Modbus proxy (optional)
+# Exposes EVCC's shared upstream connections to external Modbus/TCP clients.
+# ---------------------------------------------------------------------------
+{% if evcc_modbusproxy is defined and evcc_modbusproxy | length > 0 %}
+modbusproxy:
+{% for proxy in evcc_modbusproxy %}
+  - port: {{ proxy.port }}
+    uri: "{{ proxy.uri }}"
+    readonly: {{ proxy.readonly | default('deny') }}
+{% endfor %}
+{% endif %}
+
+# ---------------------------------------------------------------------------
 # Meters
 #
 # Production (envprod): Huawei SUN2000 hybrid + PV-only inverter connecting
-# directly to each SDongleA over Modbus/TCP — the dongle does not tolerate
-# requests forwarded through a proxy.
+# directly to each SDongleA over Modbus/TCP. EVCC's built-in modbusproxy
+# (above) re-exposes those shared connections and works since EVCC 0.313.2.
 #
 # Demo (envlocaldev): evcc `demo-meter` / `demo-battery` templates with fixed
 # `power` / `soc` values and no Modbus connection.

--- a/playbooks/ring1/templates/evcc.yaml.j2
+++ b/playbooks/ring1/templates/evcc.yaml.j2
@@ -87,6 +87,9 @@ meters:
 {%   if meter.maxchargepower is defined %}
     maxchargepower: {{ meter.maxchargepower }}
 {%   endif %}
+{%   if meter.maxdischargepower is defined %}
+    maxdischargepower: {{ meter.maxdischargepower }}
+{%   endif %}
 {%   if meter.capacity is defined %}
     capacity: {{ meter.capacity }}
 {%   endif %}

--- a/playbooks/ring1/templates/evcc.yaml.j2
+++ b/playbooks/ring1/templates/evcc.yaml.j2
@@ -29,10 +29,18 @@ interval: {{ evcc_interval }}
 #   modbus: trace
 
 # ---------------------------------------------------------------------------
-# Meters (Huawei SUN2000 hybrid + PV-only inverter)
+# Meters
 #
-# Connect directly to each Huawei SUN2000 SDongleA — the dongle does not
-# tolerate Modbus/TCP requests forwarded through a proxy.
+# Production (envprod): Huawei SUN2000 hybrid + PV-only inverter connecting
+# directly to each SDongleA over Modbus/TCP — the dongle does not tolerate
+# requests forwarded through a proxy.
+#
+# Demo (envlocaldev): evcc `demo-meter` / `demo-battery` templates with fixed
+# `power` / `soc` values and no Modbus connection.
+#
+# Each meter dict is rendered generically: connection fields
+# (modbus/host/port/id) and value fields (power/soc/…) are only emitted when
+# present, so a single template serves both the real and the demo setups.
 # ---------------------------------------------------------------------------
 meters:
 {% for meter in evcc_meters %}
@@ -40,12 +48,29 @@ meters:
     type: {{ meter.type }}
     template: {{ meter.template }}
     usage: {{ meter.usage }}
+{%   if meter.modbus is defined %}
     modbus: {{ meter.modbus }}
+{%   endif %}
+{%   if meter.host is defined %}
     host: {{ meter.host }}
+{%   endif %}
+{%   if meter.port is defined %}
     port: {{ meter.port }}
+{%   endif %}
+{%   if meter.id is defined %}
     id: {{ meter.id }}
+{%   endif %}
 {%   if meter.timeout is defined %}
     timeout: {{ meter.timeout }}
+{%   endif %}
+{%   if meter.power is defined %}
+    power: {{ meter.power }}
+{%   endif %}
+{%   if meter.soc is defined %}
+    soc: {{ meter.soc }}
+{%   endif %}
+{%   if meter.minsoc is defined %}
+    minsoc: {{ meter.minsoc }}
 {%   endif %}
 {%   if meter.maxchargepower is defined %}
     maxchargepower: {{ meter.maxchargepower }}

--- a/scripts/ha-pull-from-staging.sh
+++ b/scripts/ha-pull-from-staging.sh
@@ -53,6 +53,11 @@
 #   scripts/ha-pull-from-staging.sh root@homeassistant-staging envprod
 #   scripts/ha-pull-from-staging.sh -i ~/.ssh/ha root@10.0.0.50 envprod --dry-run
 #
+#   # Isolated envlocaldev HAOS on peladin's iso-nat bridge (jump through peladin,
+#   # ephemeral host key). Mirrors dev_ssh_common_args in the envlocaldev inventory:
+#   scripts/ha-pull-from-staging.sh -J mszmaster@incus.peladin.mszlocal \
+#       --insecure-host-key -p 8222 root@10.100.0.27 envlocaldev
+#
 # Requirements on the staging side: the SSH/community add-on with key auth.
 # The remote .storage path is auto-detected (/homeassistant or /config).
 
@@ -65,6 +70,12 @@ Usage: ha-pull-from-staging.sh [<ssh opts...>] <ssh-target> <env-name> [--dry-ru
   <ssh-target>  scp/ssh-style target (user@host)
   <env-name>    name of the env overlay under configs.private/<env>/inventory/
                 e.g. envprod, envlocaldev
+  -J, --proxy-jump <target>
+                SSH-jump through <target> (e.g. mszmaster@incus.peladin.mszlocal)
+                to reach a NAT-isolated dev instance. Applied to ssh and scp.
+  --insecure-host-key
+                do not verify/persist the target host key (for iso-nat dev VMs
+                that are recreated often and thus change keys).
   --dry-run     show what would be copied/diffed; do not modify any files
 
 The repo root is auto-detected from the script location.
@@ -93,6 +104,16 @@ while [ $# -gt 0 ]; do
       SSH_EXTRA_OPTS+=("$1" "$2")
       SCP_EXTRA_OPTS+=("$1" "$2")
       shift ;;
+    -J|--proxy-jump)
+      # SSH-jump through a bastion (e.g. peladin) to reach a NAT-isolated dev host
+      SSH_EXTRA_OPTS+=("-o" "ProxyJump=$2")
+      SCP_EXTRA_OPTS+=("-o" "ProxyJump=$2")
+      shift ;;
+    --insecure-host-key)
+      # iso-nat dev VMs are recreated often -> their host keys change
+      SSH_EXTRA_OPTS+=("-o" "StrictHostKeyChecking=no" "-o" "UserKnownHostsFile=/dev/null")
+      SCP_EXTRA_OPTS+=("-o" "StrictHostKeyChecking=no" "-o" "UserKnownHostsFile=/dev/null")
+      ;;
     *)
       if [ -z "$SSH_TARGET" ]; then
         SSH_TARGET="$1"


### PR DESCRIPTION
Integrating our Wallbox
Integrating the Car
Adding a Dashboard to Home Assistant with Car and Wallbox
Enabling EVCC Modbus Proxy
Pinning EVCC Container Versions in Terraform
Better Dev / Prod environment isolation (requires more work, but is a starting point)